### PR TITLE
Place line break before image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ If you like this project and you want to keep me awake 🤪
 <a href='https://ko-fi.com/L4L21072C' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://az743702.vo.msecnd.net/cdn/kofi1.png?v=2' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
 
 # Installation
-If you want to use this library in your processing sketch you can download it via the integrated `Contribution Manager`. 
+If you want to use this library in your processing sketch you can download it via the integrated `Contribution Manager`.
+
 ![alt install](https://github.com/Milchreis/processing-imageprocessing/blob/master/img/install.png?raw=true)
 
 # Examples


### PR DESCRIPTION
Hi,

I noticed that the image is wrapped in line with the text. This means that on some displays (like mine) the text flows from the top to the image, to the bottom. If the image has a line break before then the README looks cleaner. If you don't like this PR, let me know and I'll delete it. :)